### PR TITLE
Implement news carousel integration for projects

### DIFF
--- a/src/api/article/content-types/article/schema.json
+++ b/src/api/article/content-types/article/schema.json
@@ -218,6 +218,11 @@
     },
     "sektion_6_text": {
       "type": "blocks"
+    },
+    "relatedProject": {
+      "type": "relation",
+      "relation": "manyToOne",
+      "target": "api::article.article"
     }
   }
 }


### PR DESCRIPTION
This enables the news carousel feature on project pages by allowing multiple news articles to be linked to a single project article via a manyToOne self-referential relation.