### PR TITLE
Change relatedProject to relatedArticles with oneToMany relation

### DIFF
--- a/src/api/article/content-types/article/schema.json
+++ b/src/api/article/content-types/article/schema.json
@@ -219,9 +219,9 @@
     "sektion_6_text": {
       "type": "blocks"
     },
-    "relatedProject": {
+    "relatedArticles": {
       "type": "relation",
-      "relation": "manyToOne",
+      "relation": "oneToMany",
       "target": "api::article.article"
     }
   }


### PR DESCRIPTION
- Renamed field from relatedProject to relatedArticles
- Changed relation from manyToOne to oneToMany to allow selecting multiple news articles from a project article